### PR TITLE
removes mutable variable

### DIFF
--- a/scalaz/src/main/scala/org/atnos/origami/addon/scalaz/stream/package.scala
+++ b/scalaz/src/main/scala/org/atnos/origami/addon/scalaz/stream/package.scala
@@ -8,27 +8,30 @@ import scalaz.syntax.bind._
 
 package object stream { outer =>
 
-  def scanEval[F[_] : Monad, S, A](p: Process[F, A])(start: F[S])(f: (S, A) => F[S]): Process[F, S] = {
-    var state: S = null.asInstanceOf[S]
-    def getState: S = state
+  def scanM[F[_] : Monad : Catchable, S, A](p: Process[F, A])(start: F[S])(f: (S, A) => F[S]): Process[F, S] = {
 
-    Process.eval(start.map { s => state = s; s}) ++
-    p.zip(Process.constant(() => getState)).evalMap { case (a, s) =>
-      f(s(), a).map { newState =>
-        state = newState
-        state
-      }
-    }
+    def go(s: S, p0: Process[F, A]): Process[F, S] =
+      for {
+        pairOpt <- Process.eval(p0.unconsOption)
+        pair    <- pairOpt.fold[Process[F, (A, Process[F, A])]](Process.halt)(Process.emit)
+        s0      <- Process.eval(f(s, pair._1))
+        s1      <- Process.emit(s0) ++ go(s0, pair._2)
+      } yield s1
+
+    for {
+      s0 <- Process.eval(start)
+      s1 <- go(s0, p)
+    } yield s1
   }
 
 
   implicit class ProcessSyntax[F[_] : Monad : Catchable, A](p: Process[F, A]) {
 
-    def scanEval[S](start: F[S])(f: (S, A) => F[S]): Process[F, S] =
-      outer.scanEval(p)(start)(f)
+    def scanM[S](start: F[S])(f: (S, A) => F[S]): Process[F, S] =
+      outer.scanM(p)(start)(f)
 
     def foldWith[B](fold: Fold[F, A, B]): F[B] = {
-      p.scanEval(fold.start)(fold.fold).runLast.flatMap {
+      p.scanM(fold.start)(fold.fold).runLast.flatMap {
         case Some(s) => fold.end(s)
         case None    => fold.start.flatMap(fold.end)
       }


### PR DESCRIPTION
I've spent some time trying to remove the mutable variable and finally today realize that there's already a `peek` implementation in `scalaz-stream` :smiley: 

I've also renamed the method from `scanEval` to `scanM` as it is named in other libraries like `Pipes` and `Conduit`.

@etorreborre please review