### PR TITLE
Pure functional implementation of fs2's scanEval

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,8 @@ lazy val fs2 = project.in(file("fs2"))
   .settings(moduleSettings("fs2"))
   .settings(buildSettings)
   .settings(publishSettings)
-  .settings(libraryDependencies += "co.fs2" %% "fs2-core" % "0.10.0-RC2")
+  .settings(libraryDependencies += "org.typelevel" %% "cats-effect" % "1.0.0-RC2-8ed6e71")
+  .settings(libraryDependencies += "co.fs2" %% "fs2-core" % "0.10.4")
   .dependsOn(core, core % "test->test")
 
 def moduleSettings(moduleName: String) = Seq(

--- a/depends.sbt
+++ b/depends.sbt
@@ -1,4 +1,4 @@
-lazy val catsVersion   = "1.0.1"
+lazy val catsVersion   = "1.1.0"
 lazy val specs2Version = "4.0.2"
 
 libraryDependencies in Global ++=

--- a/fs2/src/main/scala/org/atnos/origami/addon/fs2/stream/package.scala
+++ b/fs2/src/main/scala/org/atnos/origami/addon/fs2/stream/package.scala
@@ -1,30 +1,33 @@
 package org.atnos.origami.addon.fs2
 
 import org.atnos.origami.Fold
-
-import fs2._
-import cats._
+import fs2.Stream
 import cats.syntax.functor._
 import cats.syntax.flatMap._
-import cats.effect._
+import cats.effect.Sync
+import cats.effect.concurrent.Ref
 
 package object stream { outer =>
 
-  def scanEval[F[_] : Monad, S, A](p: Stream[F, A])(start: F[S])(f: (S, A) => F[S]): Stream[F, S] = {
-    var state: S = null.asInstanceOf[S]
-    def getState: S = state
+  def scanEval[F[_]: Sync, S, A](p: Stream[F, A])(start: F[S])(f: (S, A) => F[S]): Stream[F, S] = {
 
-    Stream.eval(start.map { s => state = s; s}) ++
-    p.zip(Stream.constant(() => getState)).evalMap { case (a, s) =>
-      f(s(), a).map { newState =>
-        state = newState
-        state
+    def zipper(ref: Ref[F, S]): Stream[F, S] =
+      p.zip(Stream.eval(ref.get).repeat).evalMap { case (a, s) =>
+        for {
+          ns <- f(s, a)
+          _  <- ref.set(ns)
+        } yield ns
       }
-    }
+
+    for {
+      st  <- Stream.eval(start)
+      ref <- Stream.eval(Ref.of[F, S](st))
+      rs  <- zipper(ref)
+    } yield rs
   }
 
 
-  implicit class StreamSyntax[F[_] : Monad : Sync, A](p: Stream[F, A]) {
+  implicit class StreamSyntax[F[_]: Sync, A](p: Stream[F, A]) {
 
     def scanEval[S](start: F[S])(f: (S, A) => F[S]): Stream[F, S] =
       outer.scanEval(p)(start)(f)


### PR DESCRIPTION
Implementation of `fs2`'s `scanEval` built on top of `cats.effect.concurrent.Ref`.

I had to upgrade `Cats Effect` to `RC2` using a hash version (RC2 should be published on Friday), let me know whether you're okay with this, there's no `Ref` in `RC1`.

Alternatively, I can use `fs2.async.Ref` instead that it's actually the same that's been backported to `Cats Effect`.